### PR TITLE
Only set strategy if it's a deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This action wraps the flyctl CLI tool to allow deploying and managing fly apps.
 
 ## Usage
 
+### Deploy
+
 ```yaml
 name: Deploy to Fly
 on: [push]
@@ -14,12 +16,30 @@ jobs:
     steps:
       # This step checks out a copy of your repository.
       - uses: actions/checkout@v2
-      # This step runs `flyctl deploy`.
       - uses: superfly/flyctl-actions@master
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         with:
           args: "deploy"
+```
+
+
+### Run one off scripts
+
+```yaml
+name: Run on Fly
+on: [push]
+jobs:
+  deploy:
+    name: Run script
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: superfly/flyctl-actions@master
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        with:
+          args: "ssh console --command 'sh ./myscript.sh'"
 ```
 
 See the [flyctl](https://github.com/superfly/flyctl) GitHub project for more information on using `flyctl`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,11 @@ fi
 STRATEGY="--remote-only"
 
 for i in "$*" ; do
+  if [[ ${i} != *"deploy"* ]] ; then
+    # Strategy only relevant to deployments
+    STRATEGY=""
+    break
+  fi
   if [[ $i == "--local-only" ]] ; then
     STRATEGY="--local-only"
     break

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,18 +11,19 @@ fi
 STRATEGY="--remote-only"
 
 for i in "$*" ; do
-  if [[ ${i} != *"deploy"* ]] ; then
-    # Strategy only relevant to deployments
-    STRATEGY=""
-    break
-  fi
   if [[ $i == "--local-only" ]] ; then
     STRATEGY="--local-only"
     break
   fi
 done
 
-sh -c "flyctl $* $STRATEGY"
+if [[ $* != *"deploy"* ]] ; then
+  # Strategy only relevant to deployments
+  STRATEGY=""
+  break
+fi
+
+sh -c "echo flyctl $* $STRATEGY"
 
 ACTUAL_EXIT="$?"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,13 +17,13 @@ for i in "$*" ; do
   fi
 done
 
-if [[ $* != *"deploy"* ]] ; then
+if [[ "$*" != *"deploy"* ]] ; then
   # Strategy only relevant to deployments
   STRATEGY=""
   break
 fi
 
-sh -c "echo flyctl $* $STRATEGY"
+sh -c "flyctl $* $STRATEGY"
 
 ACTUAL_EXIT="$?"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,10 +17,9 @@ for i in "$*" ; do
   fi
 done
 
-if [[ "$*" != *"deploy"* ]] ; then
-  # Strategy only relevant to deployments
+if [[ $1 != "deploy" ]] ; then
+  # Strategy only relevant to deployments so strip if not a deploy
   STRATEGY=""
-  break
 fi
 
 sh -c "flyctl $* $STRATEGY"


### PR DESCRIPTION
Related to https://github.com/superfly/flyctl-actions/issues/13, fix for said issue.

The rationale for this change: assuming that the primary use case of this action is to invoke the `deploy` command, ensure that all other commands don't append flags that would have unexpected side effects (as I faced).

Also added some documentation to cover the case of using alternative commands