### PR TITLE
Fix bug making local-only impossible

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,9 +10,9 @@ fi
 # Default to deploying with a remote builder unless local is specified explicitly
 STRATEGY="--remote-only"
 
-for i in "$*" ; do
+for i in "$@" ; do
   if [[ $i == "--local-only" ]] ; then
-    STRATEGY="--local-only"
+    STRATEGY=""
     break
   fi
 done


### PR DESCRIPTION
This PR is unrelated to https://github.com/superfly/flyctl-actions/pull/14 but can be applied on top of it, they address different issues.

The issue is that `$*` ends up giving us all the arguments a string, so you're comparing `"deploy --local-only"` with `--local-only`,  and you end up running the command `flyctl deploy --local-only --remote-only`. This can't deploy because they cancel each-other out :)

```
==> Verifying app config
--> Verified app config
==> Building image
Error failed to fetch an image or build from source: docker is unavailable to build the deployment image
```