### PR TITLE
Print message when downloading flyctl

### DIFF
--- a/setup-flyctl/src/main.ts
+++ b/setup-flyctl/src/main.ts
@@ -16,6 +16,7 @@ async function run() {
   if (toolPath) {
     core.addPath(toolPath)
   } else {
+    core.info(`Downloading flyctl ${resolvedVersion} from ${url}...`)
     await installFlyctl(url, resolvedVersion)
   }
 


### PR DESCRIPTION
Adds a log message when downloading `flyctl` - will also hopefully help with debugging if the URL request fails.