### PR TITLE
chore: update fly tokens command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See the [flyctl](https://github.com/superfly/flyctl) GitHub project for more inf
 
 ## Secrets
 
-`FLY_API_TOKEN` - **Required**. The token to use for authentication. You can find a token by running `flyctl auth token` or going to your [user settings on fly.io](https://fly.io/user/personal_access_tokens).
+`FLY_API_TOKEN` - **Required**. The token to use for authentication. You can find a token by running `flyctl tokens create` or going to your [user settings on fly.io](https://fly.io/user/personal_access_tokens).
 
 ## Using the `setup-flyctl` action
 


### PR DESCRIPTION
When running `fly auth token` we get a warning that it is deprecated and to use `fly tokens create` instead